### PR TITLE
feat!: add `NewDefaultNativeStore` and `DynamicStore.IsAuthConfigured`

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1069,7 +1069,7 @@ func TestConfig_IsAuthConfigured(t *testing.T) {
 
 			cfg, err := Load(configPath)
 			if err != nil {
-				t.Fatal("LoadConfigFile() error =", err)
+				t.Fatal("Load() error =", err)
 			}
 			if got := cfg.IsAuthConfigured(); got != tt.want {
 				t.Errorf("IsAuthConfigured() = %v, want %v", got, tt.want)
@@ -1186,7 +1186,7 @@ func TestConfig_saveFile(t *testing.T) {
 
 			cfg, err := Load(configPath)
 			if err != nil {
-				t.Fatal("LoadConfigFile() error =", err)
+				t.Fatal("Load() error =", err)
 			}
 			cfg.credentialsStore = tt.newCfg.CredentialsStore
 			cfg.credentialHelpers = tt.newCfg.CredentialHelpers

--- a/native_store.go
+++ b/native_store.go
@@ -63,6 +63,22 @@ func NewNativeStore(helperSuffix string) Store {
 	}
 }
 
+// NewDefaultNativeStore returns a native store based on the platform-default
+// docker credentials helper and a bool indicating if the native store is
+// available.
+//   - Windows: "wincred"
+//   - Linux: "pass" or "secretservice"
+//   - macOS: "osxkeychain"
+//
+// Reference:
+//   - https://docs.docker.com/engine/reference/commandline/login/#credentials-store
+func NewDefaultNativeStore() (Store, bool) {
+	if helper := getDefaultHelperSuffix(); helper != "" {
+		return NewNativeStore(helper), true
+	}
+	return nil, false
+}
+
 // Get retrieves credentials from the store for the given server.
 func (ns *nativeStore) Get(ctx context.Context, serverAddress string) (auth.Credential, error) {
 	var cred auth.Credential

--- a/native_store_test.go
+++ b/native_store_test.go
@@ -176,3 +176,12 @@ func TestNativeStore_errorHandling(t *testing.T) {
 		t.Fatalf("should not get error when no credentials are found")
 	}
 }
+
+func TestNewDefaultNativeStore(t *testing.T) {
+	defaultHelper := getDefaultHelperSuffix()
+	wantOK := (defaultHelper != "")
+
+	if _, ok := NewDefaultNativeStore(); ok != wantOK {
+		t.Errorf("NewDefaultNativeStore() = %v, want %v", ok, wantOK)
+	}
+}

--- a/store.go
+++ b/store.go
@@ -17,6 +17,7 @@ package credentials
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,9 +43,9 @@ type Store interface {
 	Delete(ctx context.Context, serverAddress string) error
 }
 
-// dynamicStore dynamically determines which store to use based on the settings
+// DynamicStore dynamically determines which store to use based on the settings
 // in the config file.
-type dynamicStore struct {
+type DynamicStore struct {
 	config             *config.Config
 	options            StoreOptions
 	detectedCredsStore string
@@ -60,36 +61,45 @@ type StoreOptions struct {
 	//   - If AllowPlaintextPut is set to true, Put() will save credentials in
 	//     plaintext in the config file when native store is not available.
 	AllowPlaintextPut bool
+
+	// DetectDefaultCredsStore enables detecting the platform-default
+	// credentials store when the config file has no authentication information.
+	//
+	// If DetectDefaultCredsStore is set to true, the store will detect and set
+	// the default credentials store in the "credsStore" field of the config
+	// file.
+	//   - Windows: "wincred"
+	//   - Linux: "pass" or "secretservice"
+	//   - macOS: "osxkeychain"
+	//
+	// References:
+	//   - https://docs.docker.com/engine/reference/commandline/login/#credentials-store
+	//   - https://docs.docker.com/engine/reference/commandline/cli/#docker-cli-configuration-file-configjson-properties
+	DetectDefaultCredsStore bool
 }
 
 // NewStore returns a Store based on the given configuration file.
 //
-// For Get(), Put() and Delete(), the returned Store will dynamically determine which underlying credentials
-// store to use for the given server address.
+// For Get(), Put() and Delete(), the returned Store will dynamically determine
+// which underlying credentials store to use for the given server address.
 // The  underlying credentials store  is determined in the following order:
 //  1. Native server-specific credential helper
 //  2. Native credentials store
 //  3. The plain-text config file itself
 //
-// If the config file has no authentication information, a platform-default
-// native store will be used.
-//   - Windows: "wincred"
-//   - Linux: "pass" or "secretservice"
-//   - macOS: "osxkeychain"
-//
 // References:
 //   - https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 //   - https://docs.docker.com/engine/reference/commandline/cli/#docker-cli-configuration-file-configjson-properties
-func NewStore(configPath string, opts StoreOptions) (Store, error) {
+func NewStore(configPath string, opts StoreOptions) (*DynamicStore, error) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return nil, err
 	}
-	ds := &dynamicStore{
+	ds := &DynamicStore{
 		config:  cfg,
 		options: opts,
 	}
-	if !cfg.IsAuthConfigured() {
+	if opts.DetectDefaultCredsStore && !cfg.IsAuthConfigured() {
 		// no authentication configured, detect the default credentials store
 		ds.detectedCredsStore = getDefaultHelperSuffix()
 	}
@@ -106,7 +116,7 @@ func NewStore(configPath string, opts StoreOptions) (Store, error) {
 // References:
 //   - https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
 //   - https://docs.docker.com/engine/reference/commandline/cli/#change-the-docker-directory
-func NewStoreFromDocker(opt StoreOptions) (Store, error) {
+func NewStoreFromDocker(opt StoreOptions) (*DynamicStore, error) {
 	configPath, err := getDockerConfigPath()
 	if err != nil {
 		return nil, err
@@ -115,14 +125,14 @@ func NewStoreFromDocker(opt StoreOptions) (Store, error) {
 }
 
 // Get retrieves credentials from the store for the given server address.
-func (ds *dynamicStore) Get(ctx context.Context, serverAddress string) (auth.Credential, error) {
+func (ds *DynamicStore) Get(ctx context.Context, serverAddress string) (auth.Credential, error) {
 	return ds.getStore(serverAddress).Get(ctx, serverAddress)
 }
 
 // Put saves credentials into the store for the given server address.
-// Returns ErrPlaintextPutDisabled if native store is not available and
-// StoreOptions.AllowPlaintextPut is set to false.
-func (ds *dynamicStore) Put(ctx context.Context, serverAddress string, cred auth.Credential) (returnErr error) {
+// Put returns ErrPlaintextPutDisabled if native store is not available and
+// [StoreOptions].AllowPlaintextPut is set to false.
+func (ds *DynamicStore) Put(ctx context.Context, serverAddress string, cred auth.Credential) (returnErr error) {
 	if err := ds.getStore(serverAddress).Put(ctx, serverAddress, cred); err != nil {
 		return err
 	}
@@ -138,13 +148,24 @@ func (ds *dynamicStore) Put(ctx context.Context, serverAddress string, cred auth
 }
 
 // Delete removes credentials from the store for the given server address.
-func (ds *dynamicStore) Delete(ctx context.Context, serverAddress string) error {
+func (ds *DynamicStore) Delete(ctx context.Context, serverAddress string) error {
 	return ds.getStore(serverAddress).Delete(ctx, serverAddress)
+}
+
+// IsAuthConfigured returns whether there is authentication configured in the
+// config file or not.
+//
+// IsAuthConfigured returns true when:
+//   - The "credsStore" field is not empty
+//   - Or the "credHelpers" field is not empty
+//   - Or there is any entry in the "auths" field
+func (ds *DynamicStore) IsAuthConfigured() bool {
+	return ds.config.IsAuthConfigured()
 }
 
 // getHelperSuffix returns the credential helper suffix for the given server
 // address.
-func (ds *dynamicStore) getHelperSuffix(serverAddress string) string {
+func (ds *DynamicStore) getHelperSuffix(serverAddress string) string {
 	// 1. Look for a server-specific credential helper first
 	if helper := ds.config.GetCredentialHelper(serverAddress); helper != "" {
 		return helper
@@ -158,7 +179,7 @@ func (ds *dynamicStore) getHelperSuffix(serverAddress string) string {
 }
 
 // getStore returns a store for the given server address.
-func (ds *dynamicStore) getStore(serverAddress string) Store {
+func (ds *DynamicStore) getStore(serverAddress string) Store {
 	if helper := ds.getHelperSuffix(serverAddress); helper != "" {
 		return NewNativeStore(helper)
 	}
@@ -189,11 +210,14 @@ type storeWithFallbacks struct {
 }
 
 // NewStoreWithFallbacks returns a new store based on the given stores.
-//   - Get() searches the primary and the fallback stores
-//     for the credentials and returns when it finds the
-//     credentials in any of the stores.
-//   - Put() saves the credentials into the primary store.
-//   - Delete() deletes the credentials from the primary store.
+//   - Get() searches the primary and the fallback stores for the credentials
+//     and returns when it finds the credentials in any of the stores.
+//   - Put() attempts to save the credentials into the primary store. If it
+//     encounters [ErrPlaintextPutDisabled], it will attempt to save the
+//     credentials into the fallback stores one by one, until it succeeds or
+//     encounters other errors than [ErrPlaintextPutDisabled].
+//   - Delete() removes the credentials from the primary store and all the
+//     fallback stores.
 func NewStoreWithFallbacks(primary Store, fallbacks ...Store) Store {
 	if len(fallbacks) == 0 {
 		return primary
@@ -203,9 +227,8 @@ func NewStoreWithFallbacks(primary Store, fallbacks ...Store) Store {
 	}
 }
 
-// Get retrieves credentials from the StoreWithFallbacks for the given server.
-// It searches the primary and the fallback stores for the credentials of serverAddress
-// and returns when it finds the credentials in any of the stores.
+// Get searches the primary and the fallback stores for the credentials of
+// serverAddress and returns when it finds the credentials in any of the stores.
 func (sf *storeWithFallbacks) Get(ctx context.Context, serverAddress string) (auth.Credential, error) {
 	for _, s := range sf.stores {
 		cred, err := s.Get(ctx, serverAddress)
@@ -219,14 +242,32 @@ func (sf *storeWithFallbacks) Get(ctx context.Context, serverAddress string) (au
 	return auth.EmptyCredential, nil
 }
 
-// Put saves credentials into the StoreWithFallbacks. It puts
-// the credentials into the primary store.
+// Put attempts to save the credentials into the primary store. If it encounters
+// ErrPlaintextPutDisabled, it will attempt to save the credentials into the
+// fallback stores one by one, until it succeeds or encounters other errors than
+// ErrPlaintextPutDisabled.
 func (sf *storeWithFallbacks) Put(ctx context.Context, serverAddress string, cred auth.Credential) error {
-	return sf.stores[0].Put(ctx, serverAddress, cred)
+	var err error
+	for _, s := range sf.stores {
+		err = s.Put(ctx, serverAddress, cred)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrPlaintextPutDisabled) {
+			return err
+		}
+		// fallback to the next store on ErrPlaintextPutDisabled
+	}
+	return err
 }
 
-// Delete removes credentials from the StoreWithFallbacks for the given server.
-// It deletes the credentials from the primary store.
+// Delete removes the credentials from the primary store and all the fallback
+// stores.
 func (sf *storeWithFallbacks) Delete(ctx context.Context, serverAddress string) error {
-	return sf.stores[0].Delete(ctx, serverAddress)
+	for _, s := range sf.stores {
+		if err := s.Delete(ctx, serverAddress); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Features:
1. Add `NewDefaultNativeStore()`
2. Export `DynamicStore` and `DynamicStore.IsAuthConfigured`
3. Add a new option `StoreOptions.DetectDefaultCredsStore`

**BREAKING CHANGE**: When there is no authentication configured in the config file,  `DynamicStore` no longer detects and sets the platform-default docker credentials helper by default.
Fixes: #71 