### PR TITLE
fix: file store to support legacy auth keys in config files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,7 +162,20 @@ func (cfg *Config) GetCredential(serverAddress string) (auth.Credential, error) 
 
 	authCfgBytes, ok := cfg.authsCache[serverAddress]
 	if !ok {
-		return auth.EmptyCredential, nil
+		// NOTE: the auth key for the server address may have been stored with
+		// a http/https prefix in legacy config files, e.g. "registry.example.com"
+		// can be stored as "https://registry.example.com/".
+		var matched bool
+		for addr, auth := range cfg.authsCache {
+			if toHostname(addr) == serverAddress {
+				matched = true
+				authCfgBytes = auth
+				break
+			}
+		}
+		if !matched {
+			return auth.EmptyCredential, nil
+		}
 	}
 	var authCfg AuthConfig
 	if err := json.Unmarshal(authCfgBytes, &authCfg); err != nil {
@@ -299,4 +312,16 @@ func decodeAuth(authStr string) (username string, password string, err error) {
 		return "", "", fmt.Errorf("auth '%s' does not conform the base64(username:password) format", decodedStr)
 	}
 	return username, password, nil
+}
+
+// toHostname normalizes a server address to just its hostname, removing
+// the scheme and the path parts.
+// It is used to match keys in the auths map, which may be either stored as
+// hostname or as hostname including scheme (in legacy docker config files).
+// Reference: https://github.com/docker/cli/blob/v24.0.6/cli/config/credentials/file_store.go#L71
+func toHostname(addr string) string {
+	addr = strings.TrimPrefix(addr, "http://")
+	addr = strings.TrimPrefix(addr, "https://")
+	addr, _, _ = strings.Cut(addr, "/")
+	return addr
 }

--- a/testdata/legacy_auths_config.json
+++ b/testdata/legacy_auths_config.json
@@ -1,0 +1,25 @@
+{
+    "auths": {
+        "registry1.example.com": {
+            "auth": "dXNlcm5hbWUxOnBhc3N3b3JkMQ=="
+        },
+        "http://registry2.example.com": {
+            "auth": "dXNlcm5hbWUyOnBhc3N3b3JkMg=="
+        },
+        "https://registry3.example.com": {
+            "auth": "dXNlcm5hbWUzOnBhc3N3b3JkMw=="
+        },
+        "http://registry4.example.com/": {
+            "auth": "dXNlcm5hbWU0OnBhc3N3b3JkNA=="
+        },
+        "https://registry5.example.com/": {
+            "auth": "dXNlcm5hbWU1OnBhc3N3b3JkNQ=="
+        },
+        "https://registry6.example.com/path/": {
+            "auth": "dXNlcm5hbWU2OnBhc3N3b3JkNg=="
+        },
+        "https://registry1.example.com/": {
+            "auth": "Zm9vOmJhcg=="
+        }
+    }
+}


### PR DESCRIPTION
Backporting [`e8e4f84`](https://github.com/oras-project/oras-go/commit/e8e4f843df976c5a80a4b928a671a8fc9d45a9b6) from `oras-go`.

Fix: #1